### PR TITLE
Port to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-html2hamlet
-===========
+# html2hamlet
 
-A simple python script that takes an html file and outputs a hamlet file for use with Yesod
+A simple python script that takes an html file and outputs a [hamlet file](https://www.yesodweb.com/book/shakespearean-templates#shakespearean-templates_hamlet_html) for use with [Yesod](https://www.yesodweb.com/)
+
+### Requirements
+
+- Python 3
 
 ### Installation
 
@@ -24,12 +27,13 @@ virtual environment or install the dependecies globally:
 #### Usage
 
 Run:
-    
+
     python html2hamlet.py "filename.html"
-    
+
 This will output filename.hamlet into the current directory
 
 #### Features
+
 Run this script with any html file as the first argument. The output will be a
 `.hamlet` file in the current directory. All end tags are removed, all classes in any element are
 transformed to proper hamlet syntax. For example:
@@ -39,7 +43,7 @@ transformed to proper hamlet syntax. For example:
 
 becomes
 
-    <div .foo> 
+    <div .foo>
 
 And the same for Id's:
 
@@ -51,7 +55,7 @@ becomes
     <div .foo #bar>
 
 Img `src` attributes are also transformed. If you move all of the static images to the `/static/img/`
-directory of your yesod project, this *should* take care of the rest. For example:
+directory of your yesod project, this _should_ take care of the rest. For example:
 
     <img class="thumbnail" src="/static/img/myimg.jpg">
 
@@ -59,7 +63,7 @@ becomes:
 
     <img .thumbnail src=@{StaticR img_myimg_jpg}>
 
-*Note: img src links that start with `http` are omitted, so any images you're linking to will be ok*
+_Note: img src links that start with `http` are omitted, so any images you're linking to will be ok_
 
 #### TODO
 

--- a/html2hamlet.py
+++ b/html2hamlet.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup as bs
 from bs4 import Comment
 
 # get file from arg, make a Soup object
-html = bs(open(sys.argv[1]))
+html = bs(open(sys.argv[1]),features="html.parser")
 
 # extract comments from html
 comments = html.findAll(text=lambda text:isinstance(text, Comment))
@@ -13,7 +13,7 @@ comments = html.findAll(text=lambda text:isinstance(text, Comment))
 # This also puts all end tags on their own line
 prettyHtml = 'result.html'
 with open(prettyHtml, 'w') as resultout:
-    resultout.write(html.prettify('utf-8'))
+    resultout.write(html.prettify('utf-8').decode("utf-8"))
 
 # regex pattern to find end tags
 pattern = re.compile(r"\s*</.*>")
@@ -62,7 +62,7 @@ for line in fileinput.input(final, inplace=True):
   line = re.sub(r"id=\"(.*?)\"", lambda m: changeIds(m.group(1)), line.rstrip())
   line = re.sub(r'(.*<img.*src=)("(?!http).*?)(".*)', lambda m: changeImgLinks(m.groups()), line.rstrip())
   line = re.sub(r"(.*)<(.*)/>", r"\1<\2>", line.rstrip())
-  print line
+  print(line)
 
 # cleanup intermediate file
 os.remove(prettyHtml)


### PR DESCRIPTION
##### TASK
- port script to python3 #3 since python2 reached EOL beginning this year (2020)
- for more information take a look at https://docs.python.org/3/howto/pyporting.html

##### APPROACH
- fix python3 syntax error 
```bash
  File "html2hamlet.py", line 65
    print line
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(line)?
```
- add feature tag to BeautifulSoup to mute warning
```bash
html2hamlet.py:6: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 6 of the file html2hamlet.py. To get rid of this warning, pass the additional argument 'features="html.parser"' to the BeautifulSoup constructor.
```
- decode bytes, since `write()` arg must be `str`
```bash
Traceback (most recent call last):
  File "html2hamlet.py", line 16, in <module>
    resultout.write(html.prettify('utf-8'))
TypeError: write() argument must be str, not bytes
```

##### TEST
- tested with `Python 3.8.5`
- `python3 html2hamlet.py example.html`